### PR TITLE
feat(screenshot): add screenshot capability, powered by chatgtp™

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "meet-helper",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meet-helper",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "devDependencies": {
         "@types/chrome": "^0.0.224",
         "copy-webpack-plugin": "^11.0.0",
+        "ts-loader": "^9.4.2",
         "ts-node": "^10.9.1",
         "typescript": "^5.0.2",
         "webpack": "^5.76.2",
@@ -510,6 +511,21 @@
         "ajv": "^8.8.2"
       }
     },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
@@ -578,6 +594,34 @@
         }
       ]
     },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/chrome-trace-event": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
@@ -600,6 +644,24 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/colorette": {
       "version": "2.0.19",
@@ -1091,6 +1153,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
@@ -1435,6 +1509,21 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/semver": {
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/serialize-javascript": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.1.tgz",
@@ -1655,6 +1744,25 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/ts-loader": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.4.2.tgz",
+      "integrity": "sha512-OmlC4WVmFv5I0PpaxYb+qGeGOdm5giHU7HwDDUjw59emP2UYMHy9fFSDcYgSNoH8sXcj4hGCSEhlDZ9ULeDraA==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "enhanced-resolve": "^5.0.0",
+        "micromatch": "^4.0.0",
+        "semver": "^7.3.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "typescript": "*",
+        "webpack": "^5.0.0"
       }
     },
     "node_modules/ts-node": {
@@ -1958,6 +2066,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.0.tgz",
       "integrity": "sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==",
+      "dev": true
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
     "node_modules/yn": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meet-helper",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Automate several things while having meetings on Google Meet.",
   "author": {
     "name": "Muhammad Saiful Islam",
@@ -9,11 +9,13 @@
   },
   "private": true,
   "scripts": {
+    "all": "npm i && npm run build",
     "build": "webpack --config webpack/webpack.config.ts"
   },
   "devDependencies": {
     "@types/chrome": "^0.0.224",
     "copy-webpack-plugin": "^11.0.0",
+    "ts-loader": "^9.4.2",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.2",
     "webpack": "^5.76.2",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -2,9 +2,10 @@
     "manifest_version": 3,
     "name": "Meet Helper",
     "description": "Automate several things while having meetings on Google Meet.",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "permissions": [
-        "notifications"
+        "notifications",
+        "activeTab"
     ],
     "background": {
         "service_worker": "background.js"
@@ -18,5 +19,8 @@
                 "https://meet.google.com/*"
             ]
         }
-    ]
+    ],
+    "action": {
+        "default_popup": "popup.html"
+    }
 }

--- a/src/popup.html
+++ b/src/popup.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>Screen Capture</title>
+    <script src="popup.js"></script>
+  </head>
+  <body>
+    <button id="captureButton">Capture Tab</button>
+  </body>
+</html>

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -1,0 +1,20 @@
+async function captureTab() {
+    const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+    const screenshotUrl = await new Promise<string>((resolve) => {
+      chrome.tabs.captureVisibleTab(tab.windowId, { format: 'png' }, (screenshotUrl) => {
+        resolve(screenshotUrl);
+      });
+    });
+    return screenshotUrl;
+  }
+  
+  async function handleCaptureTab() {
+    const screenshotUrl = await captureTab();
+    chrome.tabs.create({ url: screenshotUrl });
+  }
+  
+  document.addEventListener('DOMContentLoaded', () => {
+    const captureButton = document.getElementById('captureButton') as HTMLButtonElement;
+    captureButton.addEventListener('click', handleCaptureTab);
+  });
+  

--- a/webpack/webpack.config.ts
+++ b/webpack/webpack.config.ts
@@ -5,20 +5,36 @@ import copyPlugin from 'copy-webpack-plugin';
 const srcDir = path.join(__dirname, '../src');
 
 const config: webpack.Configuration = {
-    mode: 'production',
-    entry: {
-        background: path.join(srcDir, 'background.ts'),
-        content: path.join(srcDir, 'content.ts')
-    },
-    output: {
-        path: path.resolve(__dirname, '../dist'),
-        clean: true
-    },
-    plugins: [
-        new copyPlugin({
-            patterns: [{ from: '.', to: '.', context: 'public' }]
-        }),
+  mode: 'production',
+  entry: {
+    background: path.join(srcDir, 'background.ts'),
+    content: path.join(srcDir, 'content.ts'),
+    popup: path.join(srcDir, 'popup.ts')
+  },
+  output: {
+    path: path.resolve(__dirname, '../dist'),
+    clean: true
+  },
+  module: {
+    rules: [
+      {
+        test: /\.tsx?$/,
+        use: 'ts-loader',
+        exclude: /node_modules/,
+      },
     ],
+  },
+  resolve: {
+    extensions: ['.tsx', '.ts', '.js'],
+  },
+  plugins: [
+    new copyPlugin({
+      patterns: [
+        { from: '.', to: '.', context: 'public' },
+        { from: 'src/popup.html', to: 'popup.html' }
+        ]
+    }),
+  ],
 };
 
 export default config;


### PR DESCRIPTION
Fixes #1 

- [x] add screenshot capability -> by clicking on plugin, user can click "capture screenshot" button and screenshot will show on new tab
- [x] add script to run `npm install & build`

Step by step:
1. click on plugin & click on "Capture Tab"
    <img width="116" alt="image" src="https://user-images.githubusercontent.com/4262799/227510810-567c1b4a-c1d9-48a3-8cec-fb370fa8a0f9.png">
2. screenshot will be shown in new tab
    ![image](https://user-images.githubusercontent.com/4262799/227510380-9d0b4cb1-087f-4029-8488-f715a555c7ce.png)


